### PR TITLE
fix: stop filtering from corrupting JSON and re-wiring nested shims

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,7 +234,12 @@ storage, unloadable filter registry).
   an agent-looking parent process. That avoids recursive shim calls and keeps
   your ordinary terminal path native. Shim captures are counted in a scrubbed
   local usage log so `ctx-wire doctor` can show whether they are actually being
-  exercised.
+  exercised. To exempt an agent-spawned helper whose stdout must stay byte-exact
+  (a statusline command, a hook, an MCP subprocess), set
+  `CTX_WIRE_DISABLE_SHIMS=1` at the top of that script: it is the first check in
+  every shim, so the real command runs unwrapped. `ctx-wire run` already sets it
+  for the commands it wraps, so nested pipelines and helpers under a wrapped
+  command stay raw.
 - **Claude Code, Cursor, Codex, Gemini CLI**: transparent command rewrite via a
   pre-tool hook. Codex additionally requires you to enable its hooks feature and
   trust the hook (the command prints the exact steps; it never bypasses trust).
@@ -519,11 +524,16 @@ wrapped and filtered, and `ctx-wire doctor` whenever something seems off.
   are passed through for the same safety reason. The rewriter is a conservative,
   POSIX-ish recognizer, not a full shell parser; `ctx-wire explain` reports the
   exact decision.
-- **JSON payload commands are not reduced.** Structured output such as `go list
-  -json`, `terraform show -json`, `terraform output -json`, and the `tofu`
-  equivalents routes to passthrough guard filters, because capping or truncating
-  JSON could produce invalid output and mislead the agent. Their non-JSON
-  variants are still compacted.
+- **JSON payloads are not reduced.** This is enforced by content, not just by
+  command: if a filter would truncate a complete, valid JSON document on stdout,
+  ctx-wire emits the document whole instead (up to ~1 MiB; a larger one is
+  replaced with a notice rather than cut mid-structure), because capping or
+  truncating JSON produces invalid output that breaks downstream parsers. So a
+  single-line JSON flowing through `cat`, a helper script, or a statusline stays
+  intact. Commands whose job is to compact JSON (`jq`) opt out with
+  `reduce_json = true` and keep capping. Known JSON commands (`go list -json`,
+  `terraform show -json`, the `tofu` equivalents) also have explicit passthrough
+  filters; their non-JSON variants are still compacted.
 - **Project filters require trust.** A project-local `.ctx-wire/filters.toml` is
   ignored until you approve it with `ctx-wire trust` (recorded by SHA-256). If
   the file changes after approval, it reverts to untrusted until re-approved.

--- a/filters/jq.toml
+++ b/filters/jq.toml
@@ -7,6 +7,9 @@ strip_lines_matching = [
 ]
 max_lines = 40
 truncate_lines_at = 120
+# jq's purpose is to compact large JSON, so it opts out of the runner's
+# content-based JSON passthrough and keeps capping its own output.
+reduce_json = true
 
 [[tests.jq]]
 name = "short output passes through"

--- a/internal/filter/filter.go
+++ b/internal/filter/filter.go
@@ -53,6 +53,12 @@ type tomlFilter struct {
 	OnEmpty            *string           `toml:"on_empty"`
 	FilterStderr       bool              `toml:"filter_stderr"`
 	GroupBy            *tomlGroupBy      `toml:"group_by"`
+	// ReduceJSON opts a filter into reducing JSON output. By default the runner
+	// passes a complete, valid JSON document through untouched (the documented
+	// "JSON payloads are not reduced" guarantee, applied by content). A filter
+	// like jq, whose whole purpose is to compact large JSON, sets this true to
+	// keep capping/truncating its JSON output.
+	ReduceJSON bool `toml:"reduce_json"`
 }
 
 // tomlGroupBy groups grep/rg-style `key:rest` output: it keeps the first
@@ -124,6 +130,7 @@ type CompiledFilter struct {
 	maxLines        *int
 	onEmpty         *string
 	groupBy         *compiledGroupBy
+	reduceJSON      bool
 }
 
 type compiledGroupBy struct {
@@ -135,6 +142,10 @@ type compiledGroupBy struct {
 
 // MaxLines exposes the absolute line cap (nil if unset).
 func (f *CompiledFilter) MaxLines() *int { return f.maxLines }
+
+// ReducesJSON reports whether this filter opts into reducing JSON output (so the
+// runner's content-based JSON passthrough must not override it).
+func (f *CompiledFilter) ReducesJSON() bool { return f.reduceJSON }
 
 // ApplyResult is the output of a filter plus metadata about whether the filter
 // dropped content due to an explicit cap.
@@ -239,6 +250,7 @@ func compile(name string, def tomlFilter) (*CompiledFilter, error) {
 		maxLines:        def.MaxLines,
 		onEmpty:         def.OnEmpty,
 		groupBy:         groupBy,
+		reduceJSON:      def.ReduceJSON,
 	}, nil
 }
 

--- a/internal/filter/filter_test.go
+++ b/internal/filter/filter_test.go
@@ -461,6 +461,27 @@ func TestApplyWithMetaReportsTruncation(t *testing.T) {
 }
 
 // firstFilter compiles inline TOML and returns its single filter.
+func TestReduceJSONFlag(t *testing.T) {
+	on := firstFilter(t, `
+schema_version = 1
+[filters.j]
+match_command = "^jq\\b"
+reduce_json = true
+`)
+	if !on.ReducesJSON() {
+		t.Error("reduce_json = true should set ReducesJSON()")
+	}
+	off := firstFilter(t, `
+schema_version = 1
+[filters.c]
+match_command = "^cat\\b"
+truncate_lines_at = 500
+`)
+	if off.ReducesJSON() {
+		t.Error("ReducesJSON() should default to false")
+	}
+}
+
 func firstFilter(t *testing.T, content string) *CompiledFilter {
 	t.Helper()
 	got, err := parseAndCompile(content, "test")

--- a/internal/runner/jsonguard_test.go
+++ b/internal/runner/jsonguard_test.go
@@ -1,0 +1,136 @@
+package runner
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"ctx-wire/internal/tee"
+)
+
+func TestIsCompleteJSON(t *testing.T) {
+	cases := map[string]bool{
+		`{"a":1}`:           true,
+		`[1,2,3]`:           true,
+		"  {\n\"a\":1\n}\n": true, // surrounding whitespace is fine
+		`{}`:                true,
+		`[INFO] not json`:   false, // bracketed log line, not JSON
+		`{broken`:           false,
+		`42`:                false, // a scalar is not a JSON payload
+		`"a string"`:        false,
+		``:                  false,
+		`   `:               false,
+		`hello world`:       false,
+	}
+	for in, want := range cases {
+		if got := isCompleteJSON(in); got != want {
+			t.Errorf("isCompleteJSON(%q) = %v, want %v", in, got, want)
+		}
+	}
+}
+
+func TestJSONGuard(t *testing.T) {
+	const doc = `{"workspace":{"dir":"/tmp/demo"},"pad":"xxxxxxxxxx"}`
+
+	// Does not fire unless the filter actually truncated a valid JSON document.
+	if _, _, ok := jsonGuard(doc, false, false, false); ok {
+		t.Error("guard fired without truncation")
+	}
+	if _, _, ok := jsonGuard(doc, true, true, false); ok {
+		t.Error("guard fired with filter_stderr (merged stream, not a pure JSON payload)")
+	}
+	if _, _, ok := jsonGuard(doc, true, false, true); ok {
+		t.Error("guard fired for a reduce_json filter (jq)")
+	}
+	if _, _, ok := jsonGuard("[INFO] noisy log line", true, false, false); ok {
+		t.Error("guard fired on non-JSON output")
+	}
+
+	// Fires for truncated valid JSON under the ceiling: emits the whole document.
+	text, mode, ok := jsonGuard(doc, true, false, false)
+	if !ok || mode != jsonModeWhole {
+		t.Fatalf("guard whole: ok=%v mode=%q", ok, mode)
+	}
+	if !json.Valid([]byte(text)) {
+		t.Errorf("emitted text is not valid JSON: %q", text)
+	}
+
+	// Over the ceiling: replaced with a notice, never a mid-structure cut.
+	defer func(old int) { maxJSONPassthrough = old }(maxJSONPassthrough)
+	maxJSONPassthrough = 16
+	text, mode, ok = jsonGuard(doc, true, false, false)
+	if !ok || mode != jsonModeCapped {
+		t.Fatalf("guard capped: ok=%v mode=%q", ok, mode)
+	}
+	if strings.Contains(text, `"workspace"`) {
+		t.Errorf("oversize JSON should be replaced, not emitted: %q", text)
+	}
+	if !strings.Contains(text, "JSON document omitted") {
+		t.Errorf("expected an omission notice, got %q", text)
+	}
+}
+
+func TestJSONGuardScrubsOnPassthrough(t *testing.T) {
+	// A secret inside passed-through JSON must still be redacted.
+	const secret = "AKIAIOSFODNN7EXAMPLE"
+	doc := `{"aws_key":"` + secret + `","note":"keep"}`
+	text, _, ok := jsonGuard(doc, true, false, false)
+	if !ok {
+		t.Fatal("guard did not fire")
+	}
+	if strings.Contains(text, secret) {
+		t.Errorf("secret leaked through JSON passthrough: %q", text)
+	}
+	if !strings.Contains(text, "[REDACTED]") {
+		t.Errorf("expected redaction marker, got %q", text)
+	}
+}
+
+// TestRunBufferedJSONPassthrough is the end-to-end reporter repro: a long
+// single-line JSON document through a truncating filter (cat) must come out
+// whole and parseable, not cut mid-string.
+func TestRunBufferedJSONPassthrough(t *testing.T) {
+	t.Setenv("CTX_WIRE_TEE_DIR", t.TempDir())
+	reg := mustRegistry(t)
+
+	payload := `{"workspace":{"current_dir":"/tmp/demo"},"padding":"` +
+		strings.Repeat("x", 2400) + `"}`
+	file := filepath.Join(t.TempDir(), "statusline.json")
+	if err := os.WriteFile(file, []byte(payload), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	out, _, _, code, err := runBuffered(context.Background(), reg, "cat",
+		[]string{file}, "cat "+file, "cat ...", tee.NewSpool("cat"))
+	if err != nil {
+		t.Fatalf("runBuffered: %v", err)
+	}
+	if code != 0 {
+		t.Fatalf("exit code = %d, want 0", code)
+	}
+	if !json.Valid([]byte(strings.TrimSpace(out))) {
+		t.Fatalf("JSON was corrupted by filtering: %q", out)
+	}
+}
+
+// TestRunBufferedDisablesNestedShims proves a wrapped command's children see
+// CTX_WIRE_DISABLE_SHIMS=1 so internal pipelines stay byte-exact.
+func TestRunBufferedDisablesNestedShims(t *testing.T) {
+	t.Setenv("CTX_WIRE_TEE_DIR", t.TempDir())
+	reg := mustRegistry(t)
+	out, _, _, code, err := runBuffered(context.Background(), reg, "sh",
+		[]string{"-c", `printf 'shims=%s' "$CTX_WIRE_DISABLE_SHIMS"`},
+		"sh -c ...", "sh -c ...", tee.NewSpool("sh"))
+	if err != nil {
+		t.Fatalf("runBuffered: %v", err)
+	}
+	if code != 0 {
+		t.Fatalf("exit code = %d, want 0", code)
+	}
+	if !strings.Contains(out, "shims=1") {
+		t.Errorf("child did not see CTX_WIRE_DISABLE_SHIMS=1, got %q", out)
+	}
+}

--- a/internal/runner/process_unix.go
+++ b/internal/runner/process_unix.go
@@ -4,12 +4,20 @@ package runner
 
 import (
 	"context"
+	"os"
 	"os/exec"
 	"syscall"
+
+	"ctx-wire/internal/shim"
 )
 
 func newCommand(ctx context.Context, name string, args ...string) *exec.Cmd {
 	cmd := exec.CommandContext(ctx, name, args...)
+	// Stop nested shims from re-wiring inside a wrapped command. The model-bound
+	// output is already captured at this level, so inner pipeline stages and
+	// helper subprocesses must run raw (byte-exact), matching the rewrite layer's
+	// "only the final pipeline stage is wrapped" contract.
+	cmd.Env = append(os.Environ(), shim.EnvDisable+"=1")
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 	cmd.Cancel = func() error {
 		if cmd.Process == nil {

--- a/internal/runner/process_windows.go
+++ b/internal/runner/process_windows.go
@@ -4,9 +4,15 @@ package runner
 
 import (
 	"context"
+	"os"
 	"os/exec"
+
+	"ctx-wire/internal/shim"
 )
 
 func newCommand(ctx context.Context, name string, args ...string) *exec.Cmd {
-	return exec.CommandContext(ctx, name, args...)
+	cmd := exec.CommandContext(ctx, name, args...)
+	// Stop nested shims from re-wiring inside a wrapped command (see process_unix.go).
+	cmd.Env = append(os.Environ(), shim.EnvDisable+"=1")
+	return cmd
 }

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -11,6 +11,7 @@ package runner
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -146,10 +147,17 @@ func runBuffered(ctx context.Context, reg *filter.Registry, name string, args []
 			SuppressSyntheticSuccess: failed,
 			KeepTailOnTruncate:       failed,
 		})
-		filterTruncated = applied.Truncated
-		stdoutText = withTrailingNewline(scrub.Scrub(applied.Output))
-		if !f.FilterStderr {
+		if jsonText, jsonMode, ok := jsonGuard(out, applied.Truncated, f.FilterStderr, f.ReducesJSON()); ok {
+			mode = jsonMode
+			stdoutText = jsonText
 			stderrText = scrub.Scrub(errOut)
+			filterTruncated = jsonMode == jsonModeCapped
+		} else {
+			filterTruncated = applied.Truncated
+			stdoutText = withTrailingNewline(scrub.Scrub(applied.Output))
+			if !f.FilterStderr {
+				stderrText = scrub.Scrub(errOut)
+			}
 		}
 	}
 
@@ -248,6 +256,51 @@ func withTrailingNewline(s string) string {
 		return s
 	}
 	return s + "\n"
+}
+
+// maxJSONPassthrough bounds how much complete JSON the content-based guarantee
+// emits verbatim. A valid JSON document up to this size is passed through whole;
+// a larger one is replaced (never cut mid-structure) so savings are preserved.
+// A var (not const) so tests can shrink it to exercise the oversize path.
+var maxJSONPassthrough = 1 << 20 // 1 MiB
+
+const (
+	jsonModeWhole  = "json"
+	jsonModeCapped = "json-capped"
+)
+
+// jsonGuard implements the documented "JSON payloads are not reduced" guarantee
+// by content. When a filter has truncated a complete, valid JSON document on
+// stdout (and is not one that intentionally reduces JSON, e.g. jq), the
+// truncation almost certainly produced invalid JSON that would break a
+// downstream parser (a statusline's jq, a piped consumer). It returns the text
+// to emit instead: the whole scrubbed document under the ceiling, or a
+// replacement notice for an oversize one, never a mid-structure cut. ok is false
+// when the guard does not apply and normal filtering should stand.
+func jsonGuard(out string, truncated, filterStderr, reducesJSON bool) (text, mode string, ok bool) {
+	if !truncated || filterStderr || reducesJSON || !isCompleteJSON(out) {
+		return "", "", false
+	}
+	if len(out) <= maxJSONPassthrough {
+		return withTrailingNewline(scrub.Scrub(out)), jsonModeWhole, true
+	}
+	return withTrailingNewline(jsonOversizeMarker(len(out))), jsonModeCapped, true
+}
+
+// isCompleteJSON reports whether s is a single complete JSON object or array.
+// The cheap first-byte gate keeps json.Valid off ordinary output, so noise that
+// merely starts with '{'/'[' (a bracketed log line, a brace expansion) is not
+// mistaken for JSON.
+func isCompleteJSON(s string) bool {
+	t := strings.TrimLeft(s, " \t\r\n")
+	if t == "" || (t[0] != '{' && t[0] != '[') {
+		return false
+	}
+	return json.Valid([]byte(s))
+}
+
+func jsonOversizeMarker(n int) string {
+	return fmt.Sprintf("[ctx-wire: %d-byte JSON document omitted (over the %d-byte passthrough ceiling); full log spooled]", n, maxJSONPassthrough)
 }
 
 func runAndExitCode(cmd *exec.Cmd) (int, error) {


### PR DESCRIPTION
Addresses the Claude statusline breakage in issue #1.

Content-based JSON guarantee: when a filter would truncate a complete, valid JSON document on stdout, ctx-wire now emits it whole (still scrubbed) up to 1 MiB, or replaces an oversize one with a notice, instead of cutting it mid-structure into invalid JSON. This honors the documented "JSON payloads are not reduced" promise by content rather than by command name, so a single-line JSON flowing through cat or a statusline helper survives. Filters whose job is to compact JSON (jq) opt out with reduce_json = true and keep capping.

Nested pipelines stay raw: ctx-wire run now sets CTX_WIRE_DISABLE_SHIMS=1 for the commands it wraps, so inner pipeline stages and helper subprocesses run byte-exact, matching the rewrite layer's "only the final pipeline stage is wrapped" contract.

Also document CTX_WIRE_DISABLE_SHIMS=1 as the per-helper opt-out for agent-spawned scripts whose stdout must stay byte-exact. The structural root (shims activating on every agent descendant) is intentionally left for a later design pass.

Refs #1